### PR TITLE
Fix briefing titles

### DIFF
--- a/briefings.html.haml
+++ b/briefings.html.haml
@@ -115,7 +115,7 @@ title: Events & Briefings
               .head-service-02
                 %i.fa.fa-gear
                 %h3
-                  %a{:href => "https://bluejeans.com/s/8HFC/"} Implementing Blue-Green and AB Deployments with OpenShift)"    
+                  %a{:href => "https://bluejeans.com/s/8HFC/"} Implementing Blue-Green and AB Deployments with OpenShift
                   %span  by Veer Muchandi, Red Hat
               .caption-service-02
                 %p In this OpenShift Commons Briefing, Veer explains the basics doing B/G and AB deployments on OpenShift.
@@ -124,7 +124,7 @@ title: Events & Briefings
               .head-service-02
                 %i.fa.fa-gear
                 %h3
-                  %a{:href => "https://youtu.be/wEL-HdoscXw"} Under the Hood: Integrating OpenShift 3 with F5"    
+                  %a{:href => "https://youtu.be/wEL-HdoscXw"} Under the Hood: Integrating OpenShift 3 with F5
                   %span By Miciah Butler Masters and Mike Barrett, Red Hat
               .caption-service-02
                 %p In this OpenShift Commons Briefing, Dan explains the basics for navigating the OpenShift 3 development tool chains to familiarize those wanting to contribute to the project with our tools.


### PR DESCRIPTION
@dmueller2001 just FYI - there were some extraneous characters in the new briefing titles but I've patched them.