### PR TITLE
docs: add build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenShift Commons
 
+[![Build Status](https://travis-ci.org/openshift/commons.openshift.org.svg?branch=master)](https://travis-ci.org/openshift/commons.openshift.org)
+
 This repo contains the sources for the [OpenShift Commons](https://commons.openshift.org/).
 
 ## Development


### PR DESCRIPTION
* Adds the build badge from travis.

Signed-off-by: Joao Goncalves <jsvgoncalves@redhat.com>