### PR TITLE
Updated OpenShift Image Builders Landing Page

### DIFF
--- a/source/sig/OpenshiftImageBuilders.html.erb
+++ b/source/sig/OpenshiftImageBuilders.html.erb
@@ -1,6 +1,6 @@
 ---
-title: OpenShift 3 Special Interest Group
-description: The principal purpose of the OpenShift 3 Special Interest Group is to collaborate and discuss items for the OpenShift 3 platform.
+title: OpenShift Image Builders Special Interest Group
+description: The principal purpose of the OpenShift 3 Special Interest Group is to collaborate and discuss Best Practices for building and maintaining Images for use with OpenShift.
 ---
 
 <% content_for :header do %>
@@ -8,7 +8,7 @@ description: The principal purpose of the OpenShift 3 Special Interest Group is 
   OpenShift 3
 </h1>
 <p class="animated fadeInUp delay">
-  The principal purpose of the OpenShift 3 Special Interest Group is to collaborate and discuss items for the OpenShift 3 platform.
+  The principal purpose of the OpenShift 3 Special Interest Group is to collaborate and discuss Best Practices for building and maintaining Images for use with OpenShift.
 </p>
 <% end %>
 
@@ -23,7 +23,7 @@ description: The principal purpose of the OpenShift 3 Special Interest Group is 
           </li>
           <li>/</li>
           <li>
-            <a href="/sig/Openshiftv3.html">OpenShift 3</a>
+            <a href="/sig/OpenshiftImageBuilders.html">OpenShift Image Builders SIG</a>
           </li>
         </ul>
       </div>
@@ -53,6 +53,15 @@ description: The principal purpose of the OpenShift 3 Special Interest Group is 
         </div>
         <div id="result-newsletter"></div>
       </div>
+    </div>
+    <div>
+    <div class="col-md-8">
+      <script class="ai1ec-widget-placeholder" data-widget="ai1ec_agenda_widget" data-events_seek_type="events" data-cat_ids="33">
+        (function(){var d=document,s=d.createElement('script'),
+        i='ai1ec-script';if(d.getElementById(i))return;s.async=1;
+        s.id=i;s.src='//live-timely-objzoywz.time.ly/?ai1ec_js_widget';
+        d.getElementsByTagName('head')[0].appendChild(s);})();
+     </script>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Fixed description (was 'OpenShift 3' now 'OpenShift Image Builder')
Fixed menu item (Was linked to 'OpenShift3' now 'OpenShift Image Builder')
Added Time.ly Calendar widget below email form