### PR TITLE
Fix spelling of "Michigan" in data/participants.yml

### DIFF
--- a/data/participants.yml
+++ b/data/participants.yml
@@ -569,7 +569,7 @@ participants:
 - name: "Univa"
   link: "http://www.univa.com/"
   logo: "commons-logos/univa.png"
-- name: "University of Michingan"
+- name: "University of Michigan"
   link: "http://umich.edu/"
   logo: "commons-logos/umich.png"
 - name: "UOL"


### PR DESCRIPTION
Michigan was misspelled in the entry for the University of Michigan in the data/participants.yml file.