### PR TITLE
logos: move participant logos into carousel

### DIFF
--- a/source/_participants_carousel.erb
+++ b/source/_participants_carousel.erb
@@ -1,0 +1,29 @@
+<div id="participant-carousel" class="carousel slide" data-ride="carousel">
+  <div class="carousel-inner">
+  <!-- carousel slides -->
+
+  <% participants_carousel.shuffle.each_slice(5).with_index do |slice, index| %>
+    <% if index == 0 %>
+    <div class="item active">
+    <% else %>
+    <div class="item">
+    <% end %>
+      <% slice.each do |participant| %>
+      <div class="participant-logo">
+        <a href="<%= participant.link %>" title="<%= participant.name %>">
+          <%= image_tag participant.logo, :alt => participant.name %>
+        </a>
+      </div>
+      <% end %>
+    </div>
+  <% end %>
+  </div>
+
+  <!-- carousel controls -->
+  <a class="left carousel-control" href="#participant-carousel" data-slide="prev">
+    <span class="glyphicon glyphicon-chevron-left"></span>
+  </a>
+  <a class="right carousel-control" href="#participant-carousel" data-slide="next">
+    <span class="glyphicon glyphicon-chevron-right"></span>
+  </a>
+</div>

--- a/source/css/_custom.scss
+++ b/source/css/_custom.scss
@@ -421,6 +421,42 @@ a.list-link {
   margin: 10px 0;
 }
 
+#participant-carousel {
+	width: 100%;
+	overflow: hidden;
+	font-size: 24px;
+	line-height: 70px;
+	padding: 10px;
+	margin: 2em auto;
+	text-align: center;
+
+	img {
+		max-width: 140px;
+		max-height: 60px;
+	}
+
+	.participant-logo {
+		display: inline-block;
+		width: 140px;
+		height: 60px;
+		margin: 5px 20px;
+	}
+
+	&.carousel.slide {
+		max-width: 100%;
+	}
+
+	&>.carousel-inner {
+		// width: 100%;
+		display: table;
+		margin: 0 auto;
+	}
+
+	.carousel-control {
+		background: none;
+	}
+}
+
 ul.participants.list {
   list-style-type: none;
   margin: 0;

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -191,11 +191,16 @@ description:  Where users, partners, customers, and contributors come together t
       </h1>
     </div>
     <div class="container">
-      <div class="search">
-        <input id="participant-search" placeholder="Search participants">
+      <div class="row">
+        <div class="col-md-12">
+          <%= partial "participants_carousel", :object => data.participants.participants %>
+        </div>
       </div>
-      <%= partial "participants", :object => data.participants.participants %>
-      <a class="list-link" href="/participants.html">View Participant List</a>
+      <div class="row">
+        <div class="col-md-12">
+          <a class="list-link" href="/participants.html">View the Full Participant List (<%= data.participants.participants.count %> members)</a>
+        </div>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
* replaces the static participant logos area with a rotating carousel,
  closes #424

Notes:
- logos' order is randomized with every site deployment
- logos are still clickable, the on-hover zoom effect is removed

Requested-by: Diane Mueller-Klingspor
Signed-off-by: Jiri Fiala <jfiala@redhat.com>