### PR TITLE
forms: Eloqua commons sign up

### DIFF
--- a/source/css/_custom.scss
+++ b/source/css/_custom.scss
@@ -736,3 +736,12 @@ ul.participants.list {
 #ai1ec-event-modal .clearfix {
   width: 100%;
 }
+
+// Eloqua form iframe
+#elq-iframe-signup-container {
+  iframe {
+	  width: 100%;
+		height: 570px; // fixed to current form
+		border: none;
+  }
+}

--- a/source/forms/_join_commons.erb
+++ b/source/forms/_join_commons.erb
@@ -1,37 +1,5 @@
-<script>
-  var submitted=false;
-</script>
 
-<iframe id="hidden_iframe" name="hidden_iframe" onload="if(submitted) {window.location='formsubmit.html';}" style="display:none;"></iframe>
-<form action="https://docs.google.com/forms/d/e/1FAIpQLScNLx9k9dVJHNZywK_-THPdpVxthJlghYDfbOZv6SgUYFVQVw/formResponse" method="post" onsubmit="submitted=true;" target="hidden_iframe">
-  <div class="form-group">
-    First Name
-    <input aria-label="First Name" class="form-control" dir="auto" id="entry_1930010579" name="entry.1930010579" required="" title="" type="text" value="">
-  </div>
-  <div class="form-group">
-    Last Name
-    <input aria-label="Last Name" class="form-control" dir="auto" id="entry_413829789" name="entry.413829789" required="" title="" type="text" value="">
-  </div>
-  <div class="form-group">
-    Company Name
-    <input aria-label="Company Name" class="form-control" dir="auto" id="entry_1964111368" name="entry.1964111368" required="" title="" type="text" value="">
-  </div>
-  <div class="form-group">
-    Email Address
-    <input aria-label="Email Address  Must enter a valid email address" class="form-control" dir="auto" id="entry_650465355" name="entry.650465355" required="" title="Must enter a valid email address" type="email" value="">
-  </div>
-  <input name="draftResponse" type="hidden" value='[,,"5508384116794069576"]'>
-  <input name="pageHistory" type="hidden" value="0">
-  <input name="fbzx" type="hidden" value="5508384116794069576">
-  <div class="ss-item ss-navigate">
-    <table id="navigation-table">
-      <tbody>
-        <tr>
-          <td class="ss-form-entry goog-inline-block" dir="ltr" id="navigation-buttons">
-            <button class="btn btn-default" name="submit" type="submit" value="Submit">Submit</button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</form>
+<!-- Eloqua form ifram (allowed domain workaround) -->
+<div id="elq-iframe-signup-container">
+  <iframe src="https://engage.redhat.com/opensource-commons-newsletter" scrolling="no"></iframe>
+</div>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -11,7 +11,7 @@ description:  Where users, partners, customers, and contributors come together t
 <% end %>
 <section class="content_info" id="join">
   <div class="info_title wow fadeInDown" id="try">
-    <i class="fa fa-users right"></i>
+    <i class="fa fa-users left"></i>
     <div class="vertical_line">
       <div class="circle_bottom"></div>
     </div>
@@ -26,7 +26,6 @@ description:  Where users, partners, customers, and contributors come together t
             <br>
             <p class="text-left">Our goals go beyond code contributions. Commons is a place for companies using OpenShift to accelerate its success and adoption. To do this we'll act as resources for each other, share best practices and provide a forum for peer-to-peer communication.</p>
           </div>
-          <h2>Join Now</h2>
           <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">
             <%= partial "forms/join_commons" %>
           </div>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -83,7 +83,7 @@
     <%= javascript_include_tag "main.js" %>
 
     <script type="text/javascript">
-    <%= content_for?(:javascript) ? yield_content(:javascript) : '' %>
+      <%= content_for?(:javascript) ? yield_content(:javascript) : '' %>
     </script>
 
     <!-- Google Remarekting -->


### PR DESCRIPTION
* replaces the commons sign up google form with an Eloqua one
* the form is loaded in an iframe
* closes #439
* partially implements #312

Requested-by: Diane Mueller-Klingspor
Signed-off-by: Jiri Fiala <jfiala@redhat.com>