### PR TITLE
videos: match height fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
     hooks (0.4.1)
       uber (~> 0.0.14)
     i18n (0.7.0)
-    json (1.8.3)
+    json (1.8.6)
     kramdown (1.9.0)
     listen (2.10.1)
       celluloid (~> 0.16.0)
@@ -123,3 +123,6 @@ DEPENDENCIES
   middleman-deploy (~> 1.0)
   tzinfo-data
   wdm (~> 0.1.0)
+
+BUNDLED WITH
+   1.13.7

--- a/source/videos.html.erb
+++ b/source/videos.html.erb
@@ -54,7 +54,13 @@ description:  OpenShift Commons Gathering Videos
 
 <% content_for :javascript do %>
   $(document).ready(function() {
-    $('.videos.active>.video').matchHeight();
-    $('.videos.active>.video>.title').matchHeight();
+    if ($('.videos.active>.video').length) {
+      $('.videos.active>.video').matchHeight();
+      $('.videos.active>.video>.title').matchHeight();
+    } else {
+      // assume no categorized videos -> no active bootstrap tab
+      $('.videos>.video').matchHeight();
+      $('.videos>.video>.title').matchHeight();
+    }
   });
 <% end %>


### PR DESCRIPTION
* matches height of video elements properly in case there would be no
  categories defined in the list (gathering_videos.yml), closes #446
* bumps the json gem to 1.8.6 (was 1.8.3)

Signed-off-by: Jiri Fiala <jfiala@redhat.com>