### PR TITLE
sig: replace Google Feed API with YQL

### DIFF
--- a/source/css/_custom.scss
+++ b/source/css/_custom.scss
@@ -745,3 +745,54 @@ ul.participants.list {
 		border: none;
   }
 }
+
+// blog feeds on SIG sign up form
+#blog-feed-sig {
+  .blog-item {
+	  margin: 0 0 5px;
+		padding-bottom: 1em;
+	}
+
+	.blog-article {
+		h3 {
+			font-size: 20px;
+		}
+		i{
+			font-size: 25px;
+			line-height: 45px;
+			float: left;
+			margin-right: 20px;
+			font-weight: lighter;
+			width: 45px;
+			height: 45px;
+			-moz-border-radius: 6px;
+			-webkit-border-radius: 6px;
+			border-radius: 6px;
+			color: #CC0000;
+			text-align: center;
+		}
+	}
+
+  @media (max-width: $screen-sm-max) {
+    .blog-item {
+			margin: 0;
+			padding-bottom: 0;
+		}
+		.blog-article {
+			h3 {
+				font-size: 12pt;
+				line-height: 24px;
+				padding-bottom: 5px;
+				border-bottom: 1px solid #E5E7E8;
+			}
+		  i {
+			  display: none;
+		  }
+		}
+
+		.blog-article-description {
+			display: none;
+		}
+	}
+
+}

--- a/source/layouts/_footer.erb
+++ b/source/layouts/_footer.erb
@@ -8,7 +8,7 @@
         </a>
       </div>
       <div class="col-md-4 col-sm-12 text-center">
-        <a href="https://hub.openshift.com/quickstarts/92-do-it-yourself-0-1" title="Powered by OpenShift Online with the DIY Cartridge">
+        <a href="https://www.openshift.com/" title="Powered by OpenShift Online">
           <img alt="Powered by OpenShift Online" src="https://www.openshift.com/sites/default/files/images/powered-transparent-white.png">
         </a>
       </div>

--- a/source/sig/OpenshiftImageBuilders.html.erb
+++ b/source/sig/OpenshiftImageBuilders.html.erb
@@ -54,15 +54,6 @@ description: The principal purpose of the OpenShift 3 Special Interest Group is 
         <div id="result-newsletter"></div>
       </div>
     </div>
-    <div>
-    <div class="col-md-8">
-     <script class="ai1ec-widget-placeholder" data-widget="ai1ec_superwidget" data-cat_ids="33">
-        (function(){var d=document,s=d.createElement('script'),
-        i='ai1ec-script';if(d.getElementById(i))return;s.async=1;
-        s.id=i;s.src='//live-timely-objzoywz.time.ly/?ai1ec_js_widget';
-        d.getElementsByTagName('head')[0].appendChild(s);})();
-</script>
-    </div>
   </div>
 </section>
 <hr style="margin:0;">

--- a/source/sig/_big_data_articles.erb
+++ b/source/sig/_big_data_articles.erb
@@ -1,61 +1,45 @@
 <% content_for :javascript do %>
-$(document).ready(function() {
-  var url = 'https://blog.openshift.com/tag/big-data/feed/';
-  var container = $("#blog");
-  var stripHtml = function(html) {
-    var tmp = document.createElement("DIV");
-    tmp.innerHTML = html;
-    return tmp.textContent || tmp.innerText || "";
+$(document).ready(function () {
+  var feedUrl = 'https://blog.openshift.com/tag/big-data/feed/';
+  var numItems = 10;
+  var blogFeedContainer = $("#blog-feed-sig");
+
+  var blogItemHtml = function(link, title, author, date, description) {
+    var blogDate = new Date(date);
+    var dateFormat = { year: 'numeric', month: 'short', day: 'numeric' };
+    htmlTemplate = '<div class="col-xs-12 col-md-6"><div class="blog-article"><div class="blog-item"><i class="fa fa-newspaper-o"></i><h3><a href="' + link + '">' + title + '</a></h3><div class="blog-article-description"><p>' + description.split(/\s+/).slice(0,20).join(" ") + '&hellip;</p></div></div></div></div>';
+    return htmlTemplate;
   };
-  var output_container = function(link, title, description) {
-    var content = stripHtml(description).split(/\s+/).slice(0,20).join(" ") + "&hellip;";
-    return "<div class='col-xs-12 col-sm-6 col-md-6 col-lg-6'><div class='service-03'><div class='head-service-03'><i class='fa fa-newspaper-o'></i><h3><a href='" + link + "' title='" + title + "'>" + title + "</a></h3></div><div class='caption-service-03'><p>" + content + " <a href='" + link + "'>Read More</a></p></div></div></div>";
-  };
+
   $.ajax({
-    type: "GET",
-    url: document.location.protocol + '//ajax.googleapis.com/ajax/services/feed/load?v=1.0&num=10&callback=?&q=' + encodeURIComponent(url),
-    dataType: 'json',
-    error: function(){
-      alert('Unable to load feed, Incorrect path or invalid feed');
+    url: "https://query.yahooapis.com/v1/public/yql",
+    jsonp: "callback",
+    dataType: "jsonp",
+    data: {
+        q: 'select title, link, pubDate, dc:creator, description from rss(0,' + numItems.toString() + ') where url="' + feedUrl + '"',
+        format: "json"
     },
-    success: function(xml) {
+    error: function() {
+      console.log("Error occurred while getting blog RSS feed!");
+    },
+    success: function( response ) {
       var output = '';
-      $(xml.responseData.feed.entries).each(function(index, entry) {
-        output += output_container(entry.link, entry.title, entry.content);
+      $(response.query.results.item).each(function(index, entry) {
+        output += blogItemHtml(entry.link, entry.title, entry.creator, entry.pubDate, entry.description);
       });
-      container.html(output);
+      blogFeedContainer.html(output);
+    },
+    complete: function() {
+      $("#blog-feed-sig .blog-article").matchHeight();
     }
   });
 });
 <% end %>
-<div id="blog">
-<%
-require 'rss'
-require 'open-uri'
 
-url = 'https://blog.openshift.com/tag/big-data/feed/'
-open(url) do |rss|
-  feed = RSS::Parser.parse(rss, false)
-  feed.channel.items.first(10).each do |item|
-%>
-<div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
-  <div class="service-03">
-    <div class="head-service-03">
-      <i class="fa fa-newspaper-o"></i>
-      <h3>
-        <a href="<%= item.link %>" title="<%= item.title %>"><%= item.title %></a>
-      </h3>
-    </div>
-    <div class="caption-service-03">
-      <p>
-        <%= item.description.split[0...20].join(' ').concat('&hellip;') %>
-        <a href="<%= item.link %>">Read More</a>
-      </p>
+<div id="blog-feed-sig">
+  <div class="row">
+    <div class="col-md-12 text-center">
+      <i class="fa fa-cog fa-spin fa-2x" aria-hidden="true"></i>
     </div>
   </div>
-</div>
-<%
-  end
-end
-%>
 </div>

--- a/source/sig/_dotnet_articles.erb
+++ b/source/sig/_dotnet_articles.erb
@@ -1,61 +1,45 @@
 <% content_for :javascript do %>
-$(document).ready(function() {
-  var url = 'https://blog.openshift.com/tag/microsoft/feed/';
-  var container = $("#blog");
-  var stripHtml = function(html) {
-    var tmp = document.createElement("DIV");
-    tmp.innerHTML = html;
-    return tmp.textContent || tmp.innerText || "";
+$(document).ready(function () {
+  var feedUrl = 'https://blog.openshift.com/tag/microsoft/feed/';
+  var numItems = 10;
+  var blogFeedContainer = $("#blog-feed-sig");
+
+  var blogItemHtml = function(link, title, author, date, description) {
+    var blogDate = new Date(date);
+    var dateFormat = { year: 'numeric', month: 'short', day: 'numeric' };
+    htmlTemplate = '<div class="col-xs-12 col-md-6"><div class="blog-article"><div class="blog-item"><i class="fa fa-newspaper-o"></i><h3><a href="' + link + '">' + title + '</a></h3><div class="blog-article-description"><p>' + description.split(/\s+/).slice(0,20).join(" ") + '&hellip;</p></div></div></div></div>';
+    return htmlTemplate;
   };
-  var output_container = function(link, title, description) {
-    var content = stripHtml(description).split(/\s+/).slice(0,20).join(" ") + "&hellip;";
-    return "<div class='col-xs-12 col-sm-6 col-md-6 col-lg-6'><div class='service-03'><div class='head-service-03'><i class='fa fa-newspaper-o'></i><h3><a href='" + link + "' title='" + title + "'>" + title + "</a></h3></div><div class='caption-service-03'><p>" + content + " <a href='" + link + "'>Read More</a></p></div></div></div>";
-  };
+
   $.ajax({
-    type: "GET",
-    url: document.location.protocol + '//ajax.googleapis.com/ajax/services/feed/load?v=1.0&num=10&callback=?&q=' + encodeURIComponent(url),
-    dataType: 'json',
-    error: function(){
-      alert('Unable to load feed, Incorrect path or invalid feed');
+    url: "https://query.yahooapis.com/v1/public/yql",
+    jsonp: "callback",
+    dataType: "jsonp",
+    data: {
+        q: 'select title, link, pubDate, dc:creator, description from rss(0,' + numItems.toString() + ') where url="' + feedUrl + '"',
+        format: "json"
     },
-    success: function(xml) {
+    error: function() {
+      console.log("Error occurred while getting blog RSS feed!");
+    },
+    success: function( response ) {
       var output = '';
-      $(xml.responseData.feed.entries).each(function(index, entry) {
-        output += output_container(entry.link, entry.title, entry.content);
+      $(response.query.results.item).each(function(index, entry) {
+        output += blogItemHtml(entry.link, entry.title, entry.creator, entry.pubDate, entry.description);
       });
-      container.html(output);
+      blogFeedContainer.html(output);
+    },
+    complete: function() {
+      $("#blog-feed-sig .blog-article").matchHeight();
     }
   });
 });
 <% end %>
-<div id="blog">
-<%
-require 'rss'
-require 'open-uri'
 
-url = 'https://blog.openshift.com/tag/microsoft/feed/'
-open(url) do |rss|
-  feed = RSS::Parser.parse(rss, false)
-  feed.channel.items.first(10).each do |item|
-%>
-<div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
-  <div class="service-03">
-    <div class="head-service-03">
-      <i class="fa fa-newspaper-o"></i>
-      <h3>
-        <a href="<%= item.link %>" title="<%= item.title %>"><%= item.title %></a>
-      </h3>
-    </div>
-    <div class="caption-service-03">
-      <p>
-        <%= item.description.split[0...20].join(' ').concat('&hellip;') %>
-        <a href="<%= item.link %>">Read More</a>
-      </p>
+<div id="blog-feed-sig">
+  <div class="row">
+    <div class="col-md-12 text-center">
+      <i class="fa fa-cog fa-spin fa-2x" aria-hidden="true"></i>
     </div>
   </div>
-</div>
-<%
-  end
-end
-%>
 </div>

--- a/source/sig/_ml_articles.erb
+++ b/source/sig/_ml_articles.erb
@@ -1,61 +1,45 @@
 <% content_for :javascript do %>
-$(document).ready(function() {
-  var url = 'https://blog.openshift.com/tag/machine-learning/feed/';
-  var container = $("#blog");
-  var stripHtml = function(html) {
-    var tmp = document.createElement("DIV");
-    tmp.innerHTML = html;
-    return tmp.textContent || tmp.innerText || "";
+$(document).ready(function () {
+  var feedUrl = 'https://blog.openshift.com/tag/machine-learning/feed/';
+  var numItems = 10;
+  var blogFeedContainer = $("#blog-feed-sig");
+
+  var blogItemHtml = function(link, title, author, date, description) {
+    var blogDate = new Date(date);
+    var dateFormat = { year: 'numeric', month: 'short', day: 'numeric' };
+    htmlTemplate = '<div class="col-xs-12 col-md-6"><div class="blog-article"><div class="blog-item"><i class="fa fa-newspaper-o"></i><h3><a href="' + link + '">' + title + '</a></h3><div class="blog-article-description"><p>' + description.split(/\s+/).slice(0,20).join(" ") + '&hellip;</p></div></div></div></div>';
+    return htmlTemplate;
   };
-  var output_container = function(link, title, description) {
-    var content = stripHtml(description).split(/\s+/).slice(0,20).join(" ") + "&hellip;";
-    return "<div class='col-xs-12 col-sm-6 col-md-6 col-lg-6'><div class='service-03'><div class='head-service-03'><i class='fa fa-newspaper-o'></i><h3><a href='" + link + "' title='" + title + "'>" + title + "</a></h3></div><div class='caption-service-03'><p>" + content + " <a href='" + link + "'>Read More</a></p></div></div></div>";
-  };
+
   $.ajax({
-    type: "GET",
-    url: document.location.protocol + '//ajax.googleapis.com/ajax/services/feed/load?v=1.0&num=10&callback=?&q=' + encodeURIComponent(url),
-    dataType: 'json',
-    error: function(){
-      alert('Unable to load feed, Incorrect path or invalid feed');
+    url: "https://query.yahooapis.com/v1/public/yql",
+    jsonp: "callback",
+    dataType: "jsonp",
+    data: {
+        q: 'select title, link, pubDate, dc:creator, description from rss(0,' + numItems.toString() + ') where url="' + feedUrl + '"',
+        format: "json"
     },
-    success: function(xml) {
+    error: function() {
+      console.log("Error occurred while getting blog RSS feed!");
+    },
+    success: function( response ) {
       var output = '';
-      $(xml.responseData.feed.entries).each(function(index, entry) {
-        output += output_container(entry.link, entry.title, entry.content);
+      $(response.query.results.item).each(function(index, entry) {
+        output += blogItemHtml(entry.link, entry.title, entry.creator, entry.pubDate, entry.description);
       });
-      container.html(output);
+      blogFeedContainer.html(output);
+    },
+    complete: function() {
+      $("#blog-feed-sig .blog-article").matchHeight();
     }
   });
 });
 <% end %>
-<div id="blog">
-<%
-require 'rss'
-require 'open-uri'
 
-url = 'https://blog.openshift.com/tag/machine-learning/feed/'
-open(url) do |rss|
-  feed = RSS::Parser.parse(rss, false)
-  feed.channel.items.first(10).each do |item|
-%>
-<div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
-  <div class="service-03">
-    <div class="head-service-03">
-      <i class="fa fa-newspaper-o"></i>
-      <h3>
-        <a href="<%= item.link %>" title="<%= item.title %>"><%= item.title %></a>
-      </h3>
-    </div>
-    <div class="caption-service-03">
-      <p>
-        <%= item.description.split[0...20].join(' ').concat('&hellip;') %>
-        <a href="<%= item.link %>">Read More</a>
-      </p>
+<div id="blog-feed-sig">
+  <div class="row">
+    <div class="col-md-12 text-center">
+      <i class="fa fa-cog fa-spin fa-2x" aria-hidden="true"></i>
     </div>
   </div>
-</div>
-<%
-  end
-end
-%>
 </div>

--- a/source/sig/_ops_articles.erb
+++ b/source/sig/_ops_articles.erb
@@ -1,61 +1,45 @@
 <% content_for :javascript do %>
-$(document).ready(function() {
-  var url = 'https://blog.openshift.com/tag/operations/feed/';
-  var container = $("#blog");
-  var stripHtml = function(html) { 
-    var tmp = document.createElement("DIV"); 
-    tmp.innerHTML = html; 
-    return tmp.textContent || tmp.innerText || ""; 
+$(document).ready(function () {
+  var feedUrl = 'https://blog.openshift.com/tag/operations/feed/';
+  var numItems = 10;
+  var blogFeedContainer = $("#blog-feed-sig");
+
+  var blogItemHtml = function(link, title, author, date, description) {
+    var blogDate = new Date(date);
+    var dateFormat = { year: 'numeric', month: 'short', day: 'numeric' };
+    htmlTemplate = '<div class="col-xs-12 col-md-6"><div class="blog-article"><div class="blog-item"><i class="fa fa-newspaper-o"></i><h3><a href="' + link + '">' + title + '</a></h3><div class="blog-article-description"><p>' + description.split(/\s+/).slice(0,20).join(" ") + '&hellip;</p></div></div></div></div>';
+    return htmlTemplate;
   };
-  var output_container = function(link, title, description) {
-    var content = stripHtml(description).split(/\s+/).slice(0,20).join(" ") + "&hellip;";
-    return "<div class='col-xs-12 col-sm-6 col-md-6 col-lg-6'><div class='service-03'><div class='head-service-03'><i class='fa fa-newspaper-o'></i><h3><a href='" + link + "' title='" + title + "'>" + title + "</a></h3></div><div class='caption-service-03'><p>" + content + " <a href='" + link + "'>Read More</a></p></div></div></div>";
-  };
+
   $.ajax({
-    type: "GET",
-    url: document.location.protocol + '//ajax.googleapis.com/ajax/services/feed/load?v=1.0&num=8&callback=?&q=' + encodeURIComponent(url),
-    dataType: 'json',
-    error: function(){
-      alert('Unable to load feed, Incorrect path or invalid feed');
+    url: "https://query.yahooapis.com/v1/public/yql",
+    jsonp: "callback",
+    dataType: "jsonp",
+    data: {
+        q: 'select title, link, pubDate, dc:creator, description from rss(0,' + numItems.toString() + ') where url="' + feedUrl + '"',
+        format: "json"
     },
-    success: function(xml) {
+    error: function() {
+      console.log("Error occurred while getting blog RSS feed!");
+    },
+    success: function( response ) {
       var output = '';
-      $(xml.responseData.feed.entries).each(function(index, entry) {
-        output += output_container(entry.link, entry.title, entry.content);
+      $(response.query.results.item).each(function(index, entry) {
+        output += blogItemHtml(entry.link, entry.title, entry.creator, entry.pubDate, entry.description);
       });
-      container.html(output);
+      blogFeedContainer.html(output);
+    },
+    complete: function() {
+      $("#blog-feed-sig .blog-article").matchHeight();
     }
   });
 });
 <% end %>
-<div id="blog">
-<%
-require 'rss'
-require 'open-uri'
 
-url = 'https://blog.openshift.com/tag/operations/feed/'
-open(url) do |rss|
-  feed = RSS::Parser.parse(rss, false)
-  feed.channel.items.first(8).each do |item|
-%>
-<div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
-  <div class="service-03">
-    <div class="head-service-03">
-      <i class="fa fa-newspaper-o"></i>
-      <h3>
-        <a href="<%= item.link %>" title="<%= item.title %>"><%= item.title %></a>
-      </h3>
-    </div>
-    <div class="caption-service-03">
-      <p>
-        <%= item.description.split[0...20].join(' ').concat('&hellip;') %>
-        <a href="<%= item.link %>">Read More</a>
-      </p>
+<div id="blog-feed-sig">
+  <div class="row">
+    <div class="col-md-12 text-center">
+      <i class="fa fa-cog fa-spin fa-2x" aria-hidden="true"></i>
     </div>
   </div>
-</div>
-<%
-  end
-end
-%>
 </div>

--- a/source/sig/_v3_articles.erb
+++ b/source/sig/_v3_articles.erb
@@ -1,61 +1,45 @@
 <% content_for :javascript do %>
-$(document).ready(function() {
-  var url = 'https://blog.openshift.com/tag/v3/feed/';
-  var container = $("#blog");
-  var stripHtml = function(html) {
-    var tmp = document.createElement("DIV");
-    tmp.innerHTML = html;
-    return tmp.textContent || tmp.innerText || "";
+$(document).ready(function () {
+  var feedUrl = 'https://blog.openshift.com/tag/v3/feed/';
+  var numItems = 10;
+  var blogFeedContainer = $("#blog-feed-sig");
+
+  var blogItemHtml = function(link, title, author, date, description) {
+    var blogDate = new Date(date);
+    var dateFormat = { year: 'numeric', month: 'short', day: 'numeric' };
+    htmlTemplate = '<div class="col-xs-12 col-md-6"><div class="blog-article"><div class="blog-item"><i class="fa fa-newspaper-o"></i><h3><a href="' + link + '">' + title + '</a></h3><div class="blog-article-description"><p>' + description.split(/\s+/).slice(0,20).join(" ") + '&hellip;</p></div></div></div></div>';
+    return htmlTemplate;
   };
-  var output_container = function(link, title, description) {
-    var content = stripHtml(description).split(/\s+/).slice(0,20).join(" ") + "&hellip;";
-    return "<div class='col-xs-12 col-sm-6 col-md-6 col-lg-6'><div class='service-03'><div class='head-service-03'><i class='fa fa-newspaper-o'></i><h3><a href='" + link + "' title='" + title + "'>" + title + "</a></h3></div><div class='caption-service-03'><p>" + content + " <a href='" + link + "'>Read More</a></p></div></div></div>";
-  };
+
   $.ajax({
-    type: "GET",
-    url: document.location.protocol + '//ajax.googleapis.com/ajax/services/feed/load?v=1.0&num=10&callback=?&q=' + encodeURIComponent(url),
-    dataType: 'json',
-    error: function(){
-      alert('Unable to load feed, Incorrect path or invalid feed');
+    url: "https://query.yahooapis.com/v1/public/yql",
+    jsonp: "callback",
+    dataType: "jsonp",
+    data: {
+        q: 'select title, link, pubDate, dc:creator, description from rss(0,' + numItems.toString() + ') where url="' + feedUrl + '"',
+        format: "json"
     },
-    success: function(xml) {
+    error: function() {
+      console.log("Error occurred while getting blog RSS feed!");
+    },
+    success: function( response ) {
       var output = '';
-      $(xml.responseData.feed.entries).each(function(index, entry) {
-        output += output_container(entry.link, entry.title, entry.content);
+      $(response.query.results.item).each(function(index, entry) {
+        output += blogItemHtml(entry.link, entry.title, entry.creator, entry.pubDate, entry.description);
       });
-      container.html(output);
+      blogFeedContainer.html(output);
+    },
+    complete: function() {
+      $("#blog-feed-sig .blog-article").matchHeight();
     }
   });
 });
 <% end %>
-<div id="blog">
-<%
-require 'rss'
-require 'open-uri'
 
-url = 'https://blog.openshift.com/tag/v3/feed/'
-open(url) do |rss|
-  feed = RSS::Parser.parse(rss, false)
-  feed.channel.items.first(10).each do |item|
-%>
-<div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
-  <div class="service-03">
-    <div class="head-service-03">
-      <i class="fa fa-newspaper-o"></i>
-      <h3>
-        <a href="<%= item.link %>" title="<%= item.title %>"><%= item.title %></a>
-      </h3>
-    </div>
-    <div class="caption-service-03">
-      <p>
-        <%= item.description.split[0...20].join(' ').concat('&hellip;') %>
-        <a href="<%= item.link %>">Read More</a>
-      </p>
+<div id="blog-feed-sig">
+  <div class="row">
+    <div class="col-md-12 text-center">
+      <i class="fa fa-cog fa-spin fa-2x" aria-hidden="true"></i>
     </div>
   </div>
-</div>
-<%
-  end
-end
-%>
 </div>


### PR DESCRIPTION
* avoids using the discontinued Google Feed API, uses YQL instead,
  closes #547
* RSS blog feeds are now parsed on runtime only, not on build time
* updates the "Powered by OpenShift" logo href to www.openshift.com
  (was OSO v2 DIY cartridge hub link)

Signed-off-by: Jiri Fiala <jfiala@redhat.com>

-----
The changes can be previewed [here](http://stage2-jfiala.rhcloud.com/index.html#interests).