### PR TITLE
sig: replace the Ops SIG form

### DIFF
--- a/source/forms/_sig_universal.erb
+++ b/source/forms/_sig_universal.erb
@@ -1,0 +1,27 @@
+<!-- Eloqua SIG form -->
+<div id="GatedFormContainer"></div>
+
+<script type="text/javascript">
+var GatedFormConfig = {
+    "hideStandardFields": [
+        "First Name",
+        "Last Name",
+        "Work Phone",
+        "Company",
+        "Department",
+        "Job Role",
+        "Country"
+    ],
+    "offer_id": "701f2000000h5MdAAI",
+    "language": "en",
+    "FormTitle": " ",
+    "FormIntro": " ",
+    "NameOrder": "western",
+    "FormCallToAction": "Submit",
+    "ThanksTitle": "Your request has been submitted.",
+    "ThanksText": "Thank you for your interest in OpenShift Commons Special Interest Groups. Your information has been submitted successfully.",
+    "ShowThanksButton": false,
+    "leadActivity": "0",
+    "disableVisitorContactLookups": false
+}
+</script>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -86,6 +86,9 @@
       <%= content_for?(:javascript) ? yield_content(:javascript) : '' %>
     </script>
 
+    <!-- Eloqua forms --->
+    <script type="text/javascript" src="https://www.redhat.com//forms/scripts/jquery.gatedform.min.js"></script>
+
     <!-- Google Remarekting -->
     <script type="text/javascript">
     /* <![CDATA[ */

--- a/source/sig/Operations.html.erb
+++ b/source/sig/Operations.html.erb
@@ -1,6 +1,6 @@
 ---
 title: OpenShift Operations Special Interest Group
-description: Collaborate and share information around best practices for operating and maintaining large scale OpenShift environments. 
+description: Collaborate and share information around best practices for operating and maintaining large scale OpenShift environments.
 ---
 
 <% content_for :header do %>
@@ -47,7 +47,7 @@ description: Collaborate and share information around best practices for operati
       <div class="container wow fadeInUp animated">
         <div class="row">
           <div class="col-xs-12 col-sm-12 col-md-6 col-md-offset-3 text-center">
-            <%= partial "forms/sig_operations" %>
+            <%= partial "forms/sig_universal" %>
           </div>
         </div>
       </div>
@@ -115,7 +115,7 @@ description: Collaborate and share information around best practices for operati
 <div class="container wow fadeInUp">
   <div class="row-fluid">
     <%= partial "sig/ops_articles" %>
-    
+
     <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
       <div class="service-03">
         <div class="head-service-03">


### PR DESCRIPTION
* Replaces the Operations SIG sign up form with an Eloqua variant

Requested-by: Diane-Mueller Klingspor
Signed-off-by: Jiri Fiala <jfiala@redhat.com>