### PR TITLE
sig: add co-cahir names to Machine Learning SIG

### DIFF
--- a/source/sig/OpenshiftMachineLearning.html.erb
+++ b/source/sig/OpenshiftMachineLearning.html.erb
@@ -51,6 +51,9 @@ description: The principal purpose of the Machine Learning on OpenShift Special 
           <div class="col-xs-12 col-sm-12 col-md-6 col-md-offset-3 text-center">
             <%= partial "forms/sig_machineLearning" %>
           </div>
+          <div class="col-xs-12 col-sm-12 col-md-10 col-md-offset-1 text-center padding-top">
+            <p class="lead"><strong>Matthew Farrellee</strong> (Red Hat) and <strong>David Aronchick</strong> (Google) co-chair this group.</p>
+          </div>
         </div>
         <div id="result-newsletter"></div>
       </div>


### PR DESCRIPTION
* adds Mathhew Farrellee's and David Aronchick's names to the Machine
  Learning SIG page, closes #551

Requested-by: Diane Mueller-Klingspor
Signed-off-by: Jiri Fiala <jfiala@redhat.com>